### PR TITLE
feature/JNG-3545 Genmodel Generator builder mandatory attributes

### DIFF
--- a/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/BuilderGenerator.mwe2
+++ b/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/BuilderGenerator.mwe2
@@ -3,6 +3,7 @@ module hu.blackbelt.eclipse.emf.genmodel.generator.builder.BuilderGenerator
 var modelDir = "model"
 var javaGenPath = "src-gen"
 var featureModifierMethodPrefix = "with"
+var nullCheckByDefault = false
 
 Workflow {	
 
@@ -10,6 +11,7 @@ Workflow {
 			config = {
 				javaGenPath = javaGenPath
 				featureModifierMethodPrefix = featureModifierMethodPrefix
+				nullCheckByDefault = nullCheckByDefault
 			}
 			doInit = true
 		}

--- a/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/BuilderGeneratorWorkflow.xtend
+++ b/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/BuilderGeneratorWorkflow.xtend
@@ -17,6 +17,7 @@ class BuilderGeneratorWorkflow extends AbstractCompositeWorkflowComponent {
 	String modelDir
 	String featureModifierMethodPrefix = "with"
 	String slot = "builderGenerator"
+	boolean nullCheckByDefault = false
 	
 	override preInvoke() {
 		val slotEntry = new ResourceLoadingSlotEntry() => [
@@ -26,6 +27,7 @@ class BuilderGeneratorWorkflow extends AbstractCompositeWorkflowComponent {
 		val config = new BuilderConfig() => [
 			setJavaGenPath(javaGenPath)
 			setFeatureModifierMethodPrefix(featureModifierMethodPrefix)
+			setNullCheckByDefault(nullCheckByDefault)
 		]
 		
 		val setup = new ModelBuilderGeneratorStandaloneSetup() => [

--- a/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/engine/BuilderConfig.xtend
+++ b/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/engine/BuilderConfig.xtend
@@ -6,4 +6,5 @@ import hu.blackbelt.eclipse.emf.genmodel.generator.core.engine.GeneratorConfig
 @Accessors
 class BuilderConfig extends GeneratorConfig {
 	String featureModifierMethodPrefix = "with"
+	boolean nullCheckByDefault = false
 }

--- a/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/templates/ModelBuilderBuilder.xtend
+++ b/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/templates/ModelBuilderBuilder.xtend
@@ -52,6 +52,7 @@ class ModelBuilderBuilder {
 		 	«ENDFOR»
 		
 		 	// helper attributes
+		 	private boolean m_nullCheck = «builderConfig.nullCheckByDefault»;
 		 	«FOR struct : structuralFeatures»
 		 		«struct.assignmentHelperDeclaration»
 		 	«ENDFOR»
@@ -87,6 +88,12 @@ class ModelBuilderBuilder {
 			 	«FOR multi : multipleStructuralFeatures»
 			 		«multi.assignFeatureMulti("_instance")»
 			 	«ENDFOR»
+                «FOR unary : unaryMandatoryStructuralFeatures»
+                    «unary.checkMandatoryFeature(it, "_instance")»
+                «ENDFOR»
+                «FOR multi : multipleMandatoryStructuralFeatures»
+                    «multi.checkMandatoryFeatureMulti(it, "_instance")»
+                «ENDFOR»
 		    	return _instance;
 			}
 
@@ -113,6 +120,14 @@ class ModelBuilderBuilder {
 		    public static «builderBuilderName()» create() {
 		        return new «builderBuilderName()»();
 		    }
+		
+		    /**
+		     * This method creates a new instance of the «builderBuilderName()» with mandatory field check if nullCheck is true.
+		     * @return new instance of the «builderBuilderName()»
+		     */
+		    public static «builderBuilderName()» create(boolean p_nullCheck) {
+		        return new «builderBuilderName()»().withNullCheck(p_nullCheck);
+		    }
 
 		    /**
 		     * This method creates a new instance of the «builderBuilderName()» from the given instance of class.
@@ -122,6 +137,18 @@ class ModelBuilderBuilder {
 		        return new «builderBuilderName()»(instance);
 		    }
 
+		    /**
+		     * This method creates a new instance of the «builderBuilderName()» from the given instance of class with mandatory field check if nullCheck is true.
+		     * @return new instance of the «builderBuilderName()»
+		     */
+		    public static «builderBuilderName()» use(«modelJavaFqName» instance, boolean p_nullCheck) {
+		        return new «builderBuilderName()»(instance).withNullCheck(p_nullCheck);
+		    }
+
+		    private «builderBuilderName()» withNullCheck(boolean p_nullCheck){
+		        m_nullCheck = p_nullCheck;
+		        return this;
+		    }
 
 		 	«FOR unary : unaryStructuralFeatures»
 		 		«unary.method(it)»
@@ -230,6 +257,18 @@ class ModelBuilderBuilder {
 		}
 		«ENDIF»
 		''' 
+		
+    def checkMandatoryFeature(GenFeature it, GenClass p_context, String p_var) '''
+        if (m_nullCheck && «p_var».get«potentiallyPluralizedName().toFirstUpper()»() == null) {
+            throw new IllegalArgumentException("Mandatory \"«safeName()»\" attribute is missing from «p_context.builderBuilderName()».");
+        }
+        ''' 
+        
+    def checkMandatoryFeatureMulti(GenFeature it, GenClass p_context, String p_var) '''
+        if (m_nullCheck && «p_var».get«potentiallyPluralizedName().toFirstUpper()»().isEmpty()) {
+            throw new IllegalArgumentException("Mandatory \"«safeName()»\" list cannot be empty in «p_context.builderBuilderName()».");
+        }
+        '''
 
 	// extension to calculate the name of the feature access method
 	def featureAccessMethod(GenFeature it) {

--- a/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/templates/ModelBuilderExtension.xtend
+++ b/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/templates/ModelBuilderExtension.xtend
@@ -9,8 +9,21 @@ import org.eclipse.emf.codegen.ecore.genmodel.GenPackage
 import org.eclipse.emf.codegen.util.CodeGenUtil
 import org.eclipse.emf.ecore.EClassifier
 import org.eclipse.emf.ecore.EClass
+import org.eclipse.emf.ecore.EDataType
+import org.eclipse.emf.ecore.EcorePackage
 
 class ModelBuilderExtension {
+    
+    protected static final val String[] PRIMITIVES = #{
+        "boolean",
+        "byte",
+        "char",
+        "double",
+        "float",
+        "int",
+        "long",
+        "short"
+    }
 			
 	def packageName (GenModel it) {
 		genPackages.get(0).basePackage + "." + genPackages.get(0).packageName;
@@ -196,6 +209,14 @@ class ModelBuilderExtension {
 	def multipleStructuralFeatures(GenClass it) {
 	    structuralFeatures.filter[isMulti]
 	}
+	
+	def unaryMandatoryStructuralFeatures(GenClass it) {
+	    structuralFeatures.filter[isMandatory && !isMulti]
+	}
+	
+	def multipleMandatoryStructuralFeatures(GenClass it) {
+        structuralFeatures.filter[isMandatory && isMulti]
+    }
 
 	// an extension to decide whether the structural feature is a list
 	def isMulti(GenFeature it) {		
@@ -223,6 +244,18 @@ class ModelBuilderExtension {
 
   	def factoryInstanceFqName(GenClass it) {
     	genPackage.packageFqName + "." + factoryInstance
+  	}
+  	
+  	def isMandatory(GenFeature it) {
+        !isPrimitive && ecoreFeature.lowerBound > 0 && (ecoreFeature.defaultValueLiteral.isNullOrEmpty && ecoreFeature.defaultValue == null)
+  	}
+  	
+  	def isNullCheck(GenClass it) {
+        structuralFeatures.findFirst[isMandatory] != null
+  	}
+  	
+  	def isPrimitive(GenFeature it) {
+  	    PRIMITIVES.contains(ecoreFeature.EType.instanceClassName)
   	}
   	  	
 }

--- a/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/templates/ModelBuilderFacade.xtend
+++ b/builder/src/main/java/hu/blackbelt/eclipse/emf/genmodel/generator/builder/templates/ModelBuilderFacade.xtend
@@ -49,6 +49,11 @@ class ModelBuilderFacade {
     public static final «builderBuilderName» new«builderBuilderName»() {
       return «builderBuilderName».create();
     }
+    «IF isNullCheck»
+        public static final «builderBuilderName» new«builderBuilderName»(boolean nullCheck) {
+          return «builderBuilderName».create(nullCheck);
+        }
+    «ENDIF»
    '''
    
    def decoratorAccessMethod(GenClass it)
@@ -56,6 +61,11 @@ class ModelBuilderFacade {
     public static final «builderBuilderName» use«name»(«modelJavaFqName» instance) {
       return «builderBuilderName».use(instance);
     }
+    «IF isNullCheck»
+        public static final «builderBuilderName» use«name»(«modelJavaFqName» instance, boolean nullCheck) {
+          return «builderBuilderName».use(instance, nullCheck);
+        }
+    «ENDIF»
    '''
 
 


### PR DESCRIPTION
JNG-3545 Added new config parameter: nullCheckByDefault
Added nullCheck bool parameter to use and new builder methods.
Added mandatory checks for required attributes to build() methods.